### PR TITLE
Fixed initial build issue with camel-sap-component

### DIFF
--- a/components/camel-sap/camel-sap-component/pom.xml
+++ b/components/camel-sap/camel-sap-component/pom.xml
@@ -128,7 +128,7 @@
 			<type>bundle</type>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
+ 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>sapjco3</artifactId>
 			<scope>system</scope>
@@ -140,7 +140,7 @@
 			<scope>system</scope>
 			<systemPath>${lib.directory}/sapidoc3.jar</systemPath>
 		</dependency>
-		<dependency>
+ 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
@@ -240,7 +240,7 @@
             		</execution>
             		<execution>
             			<id>copy-jco-libs-unit-tests</id>
-            			<phase>process-resources</phase>
+            			<phase>validate</phase>
             			<goals>
             				<goal>copy</goal>
             			</goals>


### PR DESCRIPTION
Modified camel-sap-component pom to change the phase of the 'jco-libs-unit-tests' execution of the maven-dependency-plugin to 'validate' inorder to satisfy project dependencies on first build.
