### PR TITLE
First part of fix for ENTESB-1596 Expose Camel component options

### DIFF
--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapQueuedRfcDestinationComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapQueuedRfcDestinationComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapQueuedRfcDestinationComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapQueuedRfcDestinationComponent comp = context.getComponent("sap-qrfc-destination", SapQueuedRfcDestinationComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-qrfc-destination:destinationName:queueName:rfcName?stateful=true&transacted=false");
+
+        assertEquals("true", conf.getParameter("stateful"));
+        assertEquals("false", conf.getParameter("transacted"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+        assertTrue(json.contains("\"transacted\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-qrfc-destination");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+    }
+
+}

--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapSynchronousRfcDestinationComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapSynchronousRfcDestinationComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapSynchronousRfcDestinationComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapSynchronousRfcDestinationComponent comp = context.getComponent("sap-srfc-destination", SapSynchronousRfcDestinationComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-srfc-destination:destinationName:rfcName?stateful=true&transacted=false");
+
+        assertEquals("true", conf.getParameter("stateful"));
+        assertEquals("false", conf.getParameter("transacted"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+        assertTrue(json.contains("\"transacted\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-srfc-destination");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+    }
+
+}

--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapSynchronousRfcServerComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapSynchronousRfcServerComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapSynchronousRfcServerComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapSynchronousRfcServerComponent comp = context.getComponent("sap-srfc-server", SapSynchronousRfcServerComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-srfc-server:serverName:rfcName?stateful=true");
+
+        assertEquals("true", conf.getParameter("stateful"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-srfc-server");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+        System.out.println(html);
+    }
+
+}

--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalIDocListServerComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalIDocListServerComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapTransactionalIDocListServerComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapTransactionalIDocListServerComponent comp = context.getComponent("sap-idoclist-server", SapTransactionalIDocListServerComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-idoclist-server:serverName:rfcName?stateful=true&propagateExceptions=false");
+
+        assertEquals("true", conf.getParameter("stateful"));
+        assertEquals("false", conf.getParameter("propagateExceptions"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+        assertTrue(json.contains("\"propagateExceptions\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-idoclist-server");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+    }
+
+}

--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalRfcDestinationComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalRfcDestinationComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapTransactionalRfcDestinationComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapTransactionalRfcDestinationComponent comp = context.getComponent("sap-trfc-destination", SapTransactionalRfcDestinationComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-trfc-destination:destinationName:rfcName?stateful=true&transacted=false");
+
+        assertEquals("true", conf.getParameter("stateful"));
+        assertEquals("false", conf.getParameter("transacted"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+        assertTrue(json.contains("\"transacted\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-trfc-destination");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+    }
+
+}

--- a/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalRfcServerComponentConfigurationAndDocumentationTest.java
+++ b/components/camel-sap/camel-sap-component/src/test/java/org/fusesource/camel/component/sap/SapTransactionalRfcServerComponentConfigurationAndDocumentationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.camel.component.sap;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ComponentConfiguration;
+import org.apache.camel.EndpointConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SapTransactionalRfcServerComponentConfigurationAndDocumentationTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    public void testComponentConfiguration() throws Exception {
+        SapTransactionalRfcServerComponent comp = context.getComponent("sap-trfc-server", SapTransactionalRfcServerComponent.class);
+        EndpointConfiguration conf = comp.createConfiguration("sap-trfc-server:serverName:rfcName?stateful=true&propagateExceptions=false");
+
+        assertEquals("true", conf.getParameter("stateful"));
+        assertEquals("false", conf.getParameter("propagateExceptions"));
+
+        ComponentConfiguration compConf = comp.createComponentConfiguration();
+        String json = compConf.createParameterJsonSchema();
+        assertNotNull(json);
+
+        assertTrue(json.contains("\"stateful\": { \"type\": \"boolean\" }"));
+        assertTrue(json.contains("\"propagateExceptions\": { \"type\": \"boolean\" }"));
+    }
+
+    @Ignore("See ENTESB-1586")
+    @Test
+    public void testComponentDocumentation() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        String html = context.getComponentDocumentation("sap-trfc-server");
+        assertNotNull("Should have found some auto-generated HTML if on Java 7", html);
+    }
+
+}


### PR DESCRIPTION
I've added tests for all of the components which expose options.  All of the "testComponentDocumentation" tests are marked with @Ignore for now, as I need to figure out how to update the build to generate html.
