### PR TITLE
 #17 Missing insight-elasticsearch-log-storage:jar:6.2.0.redhat-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,16 @@
                 <version>${fabric.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.fabric8.insight</groupId>
+                <artifactId>insight-elasticsearch-log-storage</artifactId>
+                <version>${fabric.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8.insight</groupId>
+                <artifactId>insight-elasticsearch-metrics-storage</artifactId>
+                <version>${fabric.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.fabric8.virt</groupId>
                 <artifactId>io.fabric8.virt.commands</artifactId>
                 <version>${fabric.version}</version>


### PR DESCRIPTION
Adding following dependencies into `dependencyManagement` solves the problem

```
            <dependency>
                <groupId>io.fabric8.insight</groupId>
                <artifactId>insight-elasticsearch-log-storage</artifactId>
                <version>${fabric.version}</version>
            </dependency>
            <dependency>
                <groupId>io.fabric8.insight</groupId>
                <artifactId>insight-elasticsearch-metrics-storage</artifactId>
                <version>${fabric.version}</version>
            </dependency>
```
