### PR TITLE
Add explicit version of insight-influxdb-metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,11 @@
                 <version>${fabric.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.fabric8.insight</groupId>
+                <artifactId>insight-influxdb-metrics</artifactId>
+                <version>${fabric.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.fabric8.virt</groupId>
                 <artifactId>io.fabric8.virt.commands</artifactId>
                 <version>${fabric.version}</version>


### PR DESCRIPTION
Without it, Maven assumend they're of transitive version
${project.version} which translated to version of fuse, not fabric8.

I had following error without this fix

```
[ERROR] Failed to execute goal on project jboss-a-mq: Could not resolve dependencies for project org.jboss.amq:jboss-a-mq:jar:6.2.0.redhat-SNAPSHOT: Could not find artifact io.fabric8.insight:insight-influxdb-metrics:jar:6.2.0.redhat-SNAPSHOT in fusesource.m2-snapshot (https://repository.jboss.org/nexus/content/groups/fs-public-snapshots/) -> [Help 1]

```
