### PR TITLE
Fix A-MQ assembly: new coordinates for patch-client artifact

### DIFF
--- a/mq/jboss-a-mq/src/main/descriptors/common-bin.xml
+++ b/mq/jboss-a-mq/src/main/descriptors/common-bin.xml
@@ -31,7 +31,7 @@
       <outputFileNameMapping>patch-client.jar</outputFileNameMapping>
       <fileMode>0644</fileMode>
       <includes>
-          <include>org.fusesource.patch:patch-client</include>
+          <include>io.fabric8.patch:patch-client</include>
       </includes>
       <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>


### PR DESCRIPTION
Just a trivial fix to the A-MQ assembly
