### PR TITLE
Entesb 2723

### DIFF
--- a/esb/esb-assembly/pom.xml
+++ b/esb/esb-assembly/pom.xml
@@ -83,17 +83,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
-            <version>${xalan.bundle.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
-            <version>${xmlresolver.bundle.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.servicemix.specs</groupId>
             <artifactId>org.apache.servicemix.specs.activator</artifactId>
             <version>${servicemix-specs-version}</version>

--- a/esb/shared/src/main/resources/common-bin.xml
+++ b/esb/shared/src/main/resources/common-bin.xml
@@ -48,8 +48,8 @@
             <outputDirectory>/lib/endorsed</outputDirectory>
             <fileMode>0644</fileMode>
             <includes>
-                <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.xalan</include>
-                <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlresolver</include>
+                <include>org.apache.servicemix.bundles:xalan</include>
+                <include>org.apache.servicemix.bundles:xmlresolver</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/esb/shared/src/main/resources/common-bin.xml
+++ b/esb/shared/src/main/resources/common-bin.xml
@@ -44,13 +44,5 @@
             <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>false</useTransitiveDependencies>
         </dependencySet>
-        <dependencySet>
-            <outputDirectory>/lib/endorsed</outputDirectory>
-            <fileMode>0644</fileMode>
-            <includes>
-                <include>org.apache.servicemix.bundles:xalan</include>
-                <include>org.apache.servicemix.bundles:xmlresolver</include>
-            </includes>
-        </dependencySet>
     </dependencySets>
 </component>

--- a/esb/shared/src/main/resources/etc/config.properties
+++ b/esb/shared/src/main/resources/etc/config.properties
@@ -12,7 +12,7 @@
 #  implied.  See the License for the specific language governing
 #  permissions and limitations under the License.
 #
-org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,org.apache.xalan.processor,org.apache.xml.utils,org.apache.xpath.jaxp,org.apache.xml.dtm.ref,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.util,org.apache.xerces.impl,org.bouncycastle*,com.ibm.security.*
+org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,org.apache.xalan.processor,org.apache.xpath.jaxp,org.apache.xml.dtm.ref,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.bouncycastle*,com.ibm.security.*
 
 org.apache.karaf.security.providers = org.bouncycastle.jce.provider.BouncyCastleProvider
 

--- a/mq/mq-assembly/jboss-a-mq-karaf/pom.xml
+++ b/mq/mq-assembly/jboss-a-mq-karaf/pom.xml
@@ -85,16 +85,6 @@
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bouncycastle-version}</version>
            </dependency>
-           <dependency>
-               <groupId>org.apache.servicemix.bundles</groupId>
-               <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
-               <version>${xalan.bundle.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.servicemix.bundles</groupId>
-               <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
-               <version>${xmlresolver.bundle.version}</version>
-           </dependency>
 
            <!-- Scala support -->
            <dependency>

--- a/mq/mq-assembly/jboss-a-mq/pom.xml
+++ b/mq/mq-assembly/jboss-a-mq/pom.xml
@@ -85,16 +85,6 @@
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bouncycastle-version}</version>
            </dependency>
-           <dependency>
-               <groupId>org.apache.servicemix.bundles</groupId>
-               <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
-               <version>${xalan.bundle.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.servicemix.bundles</groupId>
-               <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
-               <version>${xmlresolver.bundle.version}</version>
-           </dependency>
 
            <!-- Scala support -->
            <dependency>

--- a/mq/mq-assembly/shared/src/main/descriptors/common-bin.xml
+++ b/mq/mq-assembly/shared/src/main/descriptors/common-bin.xml
@@ -53,14 +53,6 @@
         </includes>
         <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>
-    <dependencySet>
-      <outputDirectory>/lib/endorsed</outputDirectory>
-      <fileMode>0644</fileMode>
-      <includes>
-        <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.xalan</include>
-        <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlresolver</include>
-      </includes>
-    </dependencySet>
   </dependencySets>
 
     <fileSets>

--- a/mq/mq-assembly/shared/src/main/resources/snippets/config.properties
+++ b/mq/mq-assembly/shared/src/main/resources/snippets/config.properties
@@ -12,7 +12,7 @@
 #  implied.  See the License for the specific language governing
 #  permissions and limitations under the License.
 #
-org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,org.apache.xalan.processor,org.apache.xml.utils,org.apache.xpath.jaxp,org.apache.xml.dtm.ref,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.util,org.apache.xerces.impl,org.bouncycastle*,com.ibm.security.*
+org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,org.apache.xalan.processor,org.apache.xpath.jaxp,org.apache.xml.dtm.ref,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.bouncycastle*,com.ibm.security.*
 
 org.apache.karaf.security.providers = org.bouncycastle.jce.provider.BouncyCastleProvider
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <groovy.version>2.1.9</groovy.version>
         <jruby.version>1.7.6-redhat.002</jruby.version>
         <scriptengines.version>1.1.1</scriptengines.version>
-        <xalan.bundle.version>2.7.2_2</xalan.bundle.version>
         <xmlresolver.bundle.version>1.2_5</xmlresolver.bundle.version>
         <jaxb-impl.bundle.version>2.2.1.1_2</jaxb-impl.bundle.version>
         <snmp4j.bundle.version>2.2.2_1</snmp4j.bundle.version>


### PR DESCRIPTION
Revert earlier changes to avoid adding xalan and xmlresolver to lib/endorsed. These libraries work without adding them to lib/endorsed. 