### PR TITLE
upgrade notices plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -35,7 +35,7 @@
         <maven-assembly-plugin-version>2.4</maven-assembly-plugin-version>
         <maven-build-helper-plugin-version>1.8</maven-build-helper-plugin-version>
         <maven-bundle-plugin-version>2.3.4</maven-bundle-plugin-version>
-        <maven-notices-plugin-version>1.31</maven-notices-plugin-version>
+        <maven-notices-plugin-version>1.38</maven-notices-plugin-version>
         <maven-surefire-plugin-version>2.16</maven-surefire-plugin-version>
     </properties>
     


### PR DESCRIPTION
On Windows we were receiving an error from the Maven/plexus process execution stuff to the effect that a command line was too long. Since the fusesource notices plugin was where the problem was showing up, I rolled the version forward to the latest (1.38), which seems to have solved the problem, though TBH I don't know precisely what changed.