### PR TITLE
Disable only bpel-xts quickstarts and disable transform-dozer quickstart.

### DIFF
--- a/esb/shared/src/main/resources/examples-unix-bin.xml
+++ b/esb/shared/src/main/resources/examples-unix-bin.xml
@@ -56,8 +56,8 @@
                 <exclude>**/target/</exclude>
                 <exclude>**/target/**</exclude>
                 <exclude>**/*.iml</exclude>
-                <exclude>**/bpel*/</exclude>
-                <exclude>**/bpel*/**</exclude>
+                <exclude>**/bpel-xts*/</exclude>
+                <exclude>**/bpel-xts*/**</exclude>
                 <exclude>**/camel-jms-binding/</exclude>
                 <exclude>**/camel-jms-binding/**</exclude>
                 <exclude>**/camel-jpa-binding/</exclude>
@@ -68,6 +68,8 @@
                 <exclude>**/demos/cluster/**</exclude>
                 <exclude>**/soap-addressing/</exclude>
                 <exclude>**/soap-addressing/**</exclude>
+                <exclude>**/transform-dozer/</exclude>
+                <exclude>**/transform-dozer/**</exclude>
                 <exclude>pom.xml</exclude>
                 <exclude>**/Readme.md</exclude>
             </excludes>


### PR DESCRIPTION
BPEL functionality has been restored in SwitchYard, so we should ship most of the bpel quickstarts (excepting bpel-xts).   transform-dozer was broken by the alignment we should stop shipping that quickstart until fixes are put in.