### PR TITLE
ENTESB-3684 New changes are not getting reflected to quickstarts

### DIFF
--- a/esb/shared/src/main/resources/common-bin.xml
+++ b/esb/shared/src/main/resources/common-bin.xml
@@ -20,6 +20,9 @@
         <fileSet>
           <outputDirectory>system</outputDirectory>
           <directory>target/features-repo</directory>
+          <excludes>
+              <exclude>org/switchyard/quickstarts/**</exclude>
+          </excludes>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
New changes are not getting reflected If Switchyard Quickstart are modified and deployed to Fuse 6.2.

https://issues.jboss.org/browse/ENTESB-3684

