### PR TITLE
Fix documentation link in readme.txt

### DIFF
--- a/esb/shared/src/main/resources/readme.txt
+++ b/esb/shared/src/main/resources/readme.txt
@@ -28,5 +28,5 @@ Documentation
 -------------
 You can find documentation online at:
 
-https://access.redhat.com/site/documentation/JBoss_Fuse/
+https://access.redhat.com/documentation/en/red-hat-jboss-fuse/
 


### PR DESCRIPTION
The link to redhat documentation is wrong https://access.redhat.com/site/documentation/JBoss_Fuse/ no longer exists