### PR TITLE
Bump version of some poms

### DIFF
--- a/esb/esb-assembly/patch-management/pom.xml
+++ b/esb/esb-assembly/patch-management/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.fuse</groupId>
         <artifactId>esb-project</artifactId>
-        <version>6.2.1.redhat-SNAPSHOT</version>
+        <version>6.3.0.redhat-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/mq-assembly/patch-management/pom.xml
+++ b/mq/mq-assembly/patch-management/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.amq</groupId>
         <artifactId>mq-project</artifactId>
-        <version>6.2.1.redhat-SNAPSHOT</version>
+        <version>6.3.0.redhat-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 


### PR DESCRIPTION
Bump versions of pom.xml to '6.3.0.redhat'

This is part of the analysis of running [Dependency Analysis](https://github.com/project-ncl/dependency-analysis) on Fuse master. Dependency Analysis failed because the versions of these 2 pom.xml are 6.2.1.redhat instead of 6.3.0.redhat.

I think that these 2 poms need to have updated versions anyways to be able to be built.

Let me know if my assumptions are wrong.
