### PR TITLE
[ENTEB-5744] align viewer,Monitor,Operator,Mainainer role

### DIFF
--- a/esb/shared/src/main/resources/etc/auth/org.apache.karaf.command.acl.osgi.cfg
+++ b/esb/shared/src/main/resources/etc/auth/org.apache.karaf.command.acl.osgi.cfg
@@ -76,5 +76,5 @@ update = Deployer, Auditor, Administrator, SuperUser, admin
 watch = Administrator, SuperUser, admin
 shutdown = Administrator, SuperUser, admin
 start-level[/.*[0-9][0-9][0-9]+.*/] = Deployer, Auditor, Administrator, SuperUser, admin # manager can set startlevels above 100
-start-level[/[^0-9]*/] = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin               # viewer can obtain the current start level
+start-level[/[^0-9]*/] = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin, viewer               # viewer can obtain the current start level
 start-level = Administrator, SuperUser, admin                           # admin can set any start level, including < 100

--- a/mq/mq-assembly/shared/src/main/resources/etc/auth/org.apache.karaf.command.acl.osgi.cfg
+++ b/mq/mq-assembly/shared/src/main/resources/etc/auth/org.apache.karaf.command.acl.osgi.cfg
@@ -76,5 +76,5 @@ update = Deployer, Auditor, Administrator, SuperUser, admin
 watch = Administrator, SuperUser, admin
 shutdown = Administrator, SuperUser, admin
 start-level[/.*[0-9][0-9][0-9]+.*/] = Deployer, Auditor, Administrator, SuperUser, admin # manager can set startlevels above 100
-start-level[/[^0-9]*/] = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin               # viewer can obtain the current start level
+start-level[/[^0-9]*/] = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin, viewer               # viewer can obtain the current start level
 start-level = Administrator, SuperUser, admin                           # admin can set any start level, including < 100


### PR DESCRIPTION
 - add viewer role to "start-level[/[^0-9]*/]" property in org.apache.karaf.command.acl.osgi.cfg