### PR TITLE
ENTESB-5799 All .jpgs in switchyard quickstarts are corrupted

### DIFF
--- a/esb/shared/src/main/resources/examples-unix-bin.xml
+++ b/esb/shared/src/main/resources/examples-unix-bin.xml
@@ -43,8 +43,8 @@
             <includes>
                 <include>**/README.md</include>
                 <include>**/pom.xml</include>
-		<include>karaf/**/README.md</include>
-		<include>karaf/**/pom.xml</include>
+                <include>karaf/**/README.md</include>
+                <include>karaf/**/pom.xml</include>
             </includes>
             <lineEnding>unix</lineEnding>
             <filtered>true</filtered>
@@ -57,6 +57,7 @@
                 <exclude>**/target/</exclude>
                 <exclude>**/target/**</exclude>
                 <exclude>**/*.iml</exclude>
+                <exclude>**/*.jpg</exclude>
                 <exclude>**/bpel-xts*/</exclude>
                 <exclude>**/bpel-xts*/**</exclude>
                 <exclude>**/camel-jms-binding/</exclude>
@@ -95,6 +96,7 @@
             <directory>target/shared/syquickstarts</directory>
             <outputDirectory>/quickstarts/switchyard</outputDirectory>
             <includes>
+                <include>**/*.jpg</include>
                 <include>**/camel-ftp-binding/src/test/resources/ftpclient.jks</include>
                 <include>**/camel-ftp-binding/src/test/resources/ftpserver.jks</include>
                 <include>**/camel-netty-binding/users.jks</include>
@@ -133,6 +135,9 @@
                 <exclude>**/soap-addressing/</exclude>
                 <exclude>**/soap-addressing/**</exclude>
                 
+                <!-- Exclude all JPG files -->
+                <exclude>**/*.jpg</exclude>
+
                 <!-- Exclude all JKS files, which get corrupted by filtering -->
                 <exclude>**/camel-ftp-binding/src/test/resources/ftpclient.jks</exclude>
                 <exclude>**/camel-ftp-binding/src/test/resources/ftpserver.jks</exclude>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5799