### PR TITLE
ENTESB-5730 - Fix RBAC and ACL config for Fuse 6.3

### DIFF
--- a/esb/shared/src/main/resources/etc/auth/jmx.acl.io.fabric8.Fabric.cfg
+++ b/esb/shared/src/main/resources/etc/auth/jmx.acl.io.fabric8.Fabric.cfg
@@ -1,0 +1,23 @@
+#
+#  Copyright 2005-2016 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+#
+# JMX ACL specific to io.fabric8.Fabric MBean
+#
+# For a description of the format of this file, see jmx.acl.cfg
+#
+versions = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin, viewer
+

--- a/mq/mq-assembly/shared/src/main/resources/etc/auth/jmx.acl.io.fabric8.Fabric.cfg
+++ b/mq/mq-assembly/shared/src/main/resources/etc/auth/jmx.acl.io.fabric8.Fabric.cfg
@@ -1,0 +1,23 @@
+#
+#  Copyright 2005-2016 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+#
+# JMX ACL specific to io.fabric8.Fabric MBean
+#
+# For a description of the format of this file, see jmx.acl.cfg
+#
+versions = Monitor, Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser, admin, viewer
+


### PR DESCRIPTION
Allow viewer role for 'versions' op in io.fabric8.Fabric

https://issues.jboss.org/browse/ENTESB-5730