### PR TITLE
Revert "ENTESB-2117 - set max size for tx log"

### DIFF
--- a/esb/shared/src/main/resources/etc/org.apache.aries.transaction.cfg
+++ b/esb/shared/src/main/resources/etc/org.apache.aries.transaction.cfg
@@ -14,10 +14,6 @@
 #  permissions and limitations under the License.
 #
 
-aries.transaction.recoverable = true
-aries.transaction.timeout = 600
-aries.transaction.howl.logFileDir = ${karaf.data}/txlog
-aries.transaction.howl.maxLogFiles = 2
-aries.transaction.howl.maxBlocksPerFile = 512
-aries.transaction.howl.bufferSize = 4
-
+aries.transaction.timeout=600
+aries.transaction.howl.logFileDir=${karaf.data}/txlog/
+aries.transaction.recoverable=true


### PR DESCRIPTION
This reverts commit af1530655882b515dbf40604942d34741012d47b.

Need to revert until we get https://issues.apache.org/jira/browse/ARIES-1719 fixed.