### PR TITLE
Plugin version changes for prod builds

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,7 +36,7 @@
         <maven-assembly-plugin-version>3.1.1</maven-assembly-plugin-version>
         <maven-build-helper-plugin-version>1.8</maven-build-helper-plugin-version>
         <maven-bundle-plugin-version>2.3.4</maven-bundle-plugin-version>
-        <maven-notices-plugin-version>1.42</maven-notices-plugin-version>
+        <maven-notices-plugin-version>1.42.0.redhat-00001</maven-notices-plugin-version>
         <maven-surefire-plugin-version>2.19</maven-surefire-plugin-version>
 	<maven-surefire-itests-plugin-version>2.17</maven-surefire-itests-plugin-version>
     </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,7 +33,7 @@
     <name>JBoss Fuse :: Parent</name>
 
     <properties>
-        <maven-assembly-plugin-version>2.5.5</maven-assembly-plugin-version>
+        <maven-assembly-plugin-version>3.1.1</maven-assembly-plugin-version>
         <maven-build-helper-plugin-version>1.8</maven-build-helper-plugin-version>
         <maven-bundle-plugin-version>2.3.4</maven-bundle-plugin-version>
         <maven-notices-plugin-version>1.42</maven-notices-plugin-version>


### PR DESCRIPTION
Bump to maven-assembly-plugin to prevent 'too many open files' error
Use of productised maven-notices-plugin so user properties can be passed to it.